### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/code-sleuth/scrutiny/compare/v0.1.1...v0.1.2) - 2025-01-10
+
+### Other
+
+- fix condition
+- use v0.5
+- upload assets
+
 ## [0.1.1](https://github.com/code-sleuth/scrutiny/compare/v0.1.0...v0.1.1) - 2025-01-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "scruitny"
-version = "0.1.1"
+version = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "scruitny"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 homepage = "https://github.com/code-sleuth/scrutiny"
 repository = "https://github.com/code-sleuth/scrutiny"


### PR DESCRIPTION
## 🤖 New release
* `scruitny`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/code-sleuth/scrutiny/compare/v0.1.1...v0.1.2) - 2025-01-10

### Other

- fix condition
- use v0.5
- upload assets
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).