### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/code-sleuth/scrutiny/compare/v0.1.4...v0.1.5) - 2025-01-10
+
+### Other
+
+- debug
+- debug
+- debug
+
 ## [0.1.4](https://github.com/code-sleuth/scrutiny/compare/v0.1.3...v0.1.4) - 2025-01-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "scruitny"
-version = "0.1.4"
+version = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "scruitny"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 homepage = "https://github.com/code-sleuth/scrutiny"
 repository = "https://github.com/code-sleuth/scrutiny"


### PR DESCRIPTION
## 🤖 New release
* `scruitny`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/code-sleuth/scrutiny/compare/v0.1.4...v0.1.5) - 2025-01-10

### Other

- debug
- debug
- debug
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).